### PR TITLE
fix: replace deprecated datetime.utcnow() with datetime.now(timezone.utc)

### DIFF
--- a/src/asi_build/safety/formal_verification.py
+++ b/src/asi_build/safety/formal_verification.py
@@ -17,7 +17,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
@@ -225,7 +225,7 @@ class TheoremProver:
         self, hypothesis: List[str], conclusion: str, method: str = "resolution"
     ) -> FormalProof:
         """Attempt to prove a theorem using specified method."""
-        start_time = datetime.utcnow()
+        start_time = datetime.now(timezone.utc)
 
         try:
             if method == "resolution":
@@ -237,7 +237,7 @@ class TheoremProver:
             else:
                 raise ValueError(f"Unknown proof method: {method}")
 
-            end_time = datetime.utcnow()
+            end_time = datetime.now(timezone.utc)
             verification_time = (end_time - start_time).total_seconds()
 
             formal_proof = FormalProof(
@@ -661,7 +661,7 @@ class TheoremProver:
 
     def _generate_proof_id(self) -> str:
         """Generate unique proof ID."""
-        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
         return f"proof_{timestamp}_{id(self) % 10000}"
 
 

--- a/src/asi_build/safety/governance/consensus.py
+++ b/src/asi_build/safety/governance/consensus.py
@@ -12,7 +12,7 @@ import logging
 import math
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -154,7 +154,7 @@ class QuadraticVotingSystem:
                 vote_intensity=vote_intensity,
                 token_cost=cost,
                 reasoning=reasoning,
-                cast_at=datetime.utcnow(),
+                cast_at=datetime.now(timezone.utc),
             )
 
             # Store vote
@@ -258,7 +258,7 @@ class LiquidDemocracy:
                 voting_power=voting_power,
                 expiration=expiration,
                 revocable=True,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
             )
 
             # Store delegation
@@ -394,7 +394,7 @@ class LiquidDemocracy:
 
     def _is_delegation_active(self, delegation: Delegation) -> bool:
         """Check if a delegation is currently active."""
-        if delegation.expiration and datetime.utcnow() > delegation.expiration:
+        if delegation.expiration and datetime.now(timezone.utc) > delegation.expiration:
             return False
         return True
 
@@ -440,7 +440,7 @@ class MultiStakeholderConsensus:
     ) -> str:
         """Initiate a new consensus process."""
         try:
-            process_id = f"consensus_{proposal_id}_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+            process_id = f"consensus_{proposal_id}_{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}"
 
             # Define process phases
             phases = []
@@ -451,7 +451,7 @@ class MultiStakeholderConsensus:
 
             # Calculate phase deadlines
             phase_deadlines = {}
-            base_time = datetime.utcnow()
+            base_time = datetime.now(timezone.utc)
 
             phase_durations = {
                 "information": timedelta(days=2),
@@ -484,7 +484,7 @@ class MultiStakeholderConsensus:
                 deliberation_log=[],
                 status=ConsensusStatus.GATHERING,
                 final_result=None,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
             )
 
             self.consensus_processes[process_id] = process
@@ -550,7 +550,7 @@ class MultiStakeholderConsensus:
                 "effective_power": effective_power,
                 "direction": vote_data["direction"],
                 "reasoning": vote_data.get("reasoning", ""),
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             }
 
         return success, message
@@ -577,7 +577,7 @@ class MultiStakeholderConsensus:
             "direction": vote_data["direction"],
             "reasoning": vote_data.get("reasoning", ""),
             "delegation_chain": self.liquid_democracy.get_delegation_chain(stakeholder.id, scope),
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
         return True, "Liquid democracy vote cast successfully"
@@ -596,7 +596,7 @@ class MultiStakeholderConsensus:
             "effective_power": effective_power,
             "direction": vote_data["direction"],
             "reasoning": vote_data.get("reasoning", ""),
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
         return True, "Weighted vote cast successfully"
@@ -656,7 +656,7 @@ class MultiStakeholderConsensus:
             process.final_result = {
                 "consensus_reached": consensus_reached,
                 "results": results,
-                "finalized_at": datetime.utcnow().isoformat(),
+                "finalized_at": datetime.now(timezone.utc).isoformat(),
             }
 
             process.status = (

--- a/src/asi_build/safety/governance/contracts.py
+++ b/src/asi_build/safety/governance/contracts.py
@@ -14,7 +14,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -96,7 +96,7 @@ class SmartContract(ABC):
         self.storage: Dict[str, Any] = {}
         self.permissions: List[ContractPermission] = []
         self.events: List[ContractEvent] = []
-        self.deployed_at = datetime.utcnow()
+        self.deployed_at = datetime.now(timezone.utc)
         self.version = "1.0.0"
 
         # Set up default permissions
@@ -194,7 +194,7 @@ class SmartContract(ABC):
             parameters=parameters,
             block_height=transaction_context.get("block_height", 0),
             transaction_hash=transaction_context.get("transaction_hash", ""),
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
         )
         self.events.append(event)
 
@@ -417,7 +417,7 @@ class ProposalContract(SmartContract):
         proposal_id = self.storage["proposal_counter"] + 1
         self.storage["proposal_counter"] = proposal_id
 
-        voting_end = datetime.utcnow() + timedelta(seconds=self.storage["voting_period"])
+        voting_end = datetime.now(timezone.utc) + timedelta(seconds=self.storage["voting_period"])
 
         proposal = {
             "id": proposal_id,
@@ -430,7 +430,7 @@ class ProposalContract(SmartContract):
             "votes_abstain": 0,
             "voters": {},
             "status": "voting",
-            "created_at": datetime.utcnow().isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
             "voting_end": voting_end.isoformat(),
             "executed": False,
         }
@@ -463,7 +463,7 @@ class ProposalContract(SmartContract):
             raise ValueError("Proposal not in voting phase")
 
         voting_end = datetime.fromisoformat(proposal["voting_end"])
-        if datetime.utcnow() > voting_end:
+        if datetime.now(timezone.utc) > voting_end:
             raise ValueError("Voting period has ended")
 
         if voter in proposal["voters"]:
@@ -473,7 +473,7 @@ class ProposalContract(SmartContract):
         proposal["voters"][voter] = {
             "vote_type": vote_type,
             "voting_power": voting_power,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
         # Update vote counts
@@ -510,7 +510,7 @@ class ProposalContract(SmartContract):
             raise ValueError("Proposal not in voting phase")
 
         voting_end = datetime.fromisoformat(proposal["voting_end"])
-        if datetime.utcnow() <= voting_end:
+        if datetime.now(timezone.utc) <= voting_end:
             raise ValueError("Voting period not yet ended")
 
         # Calculate results
@@ -535,7 +535,7 @@ class ProposalContract(SmartContract):
 
         proposal["participation_rate"] = participation_rate
         proposal["approval_rate"] = approval_rate
-        proposal["finalized_at"] = datetime.utcnow().isoformat()
+        proposal["finalized_at"] = datetime.now(timezone.utc).isoformat()
 
         self._emit_event(
             "ProposalFinalized",
@@ -565,7 +565,7 @@ class ProposalContract(SmartContract):
 
         # Mark as executed
         proposal["executed"] = True
-        proposal["executed_at"] = datetime.utcnow().isoformat()
+        proposal["executed_at"] = datetime.now(timezone.utc).isoformat()
 
         self._emit_event(
             "ProposalExecuted",
@@ -586,7 +586,7 @@ class ProposalContract(SmartContract):
 
         proposal["status"] = "vetoed"
         proposal["veto_reason"] = reason
-        proposal["vetoed_at"] = datetime.utcnow().isoformat()
+        proposal["vetoed_at"] = datetime.now(timezone.utc).isoformat()
         proposal["vetoed_by"] = transaction_context["caller"]
 
         self._emit_event(
@@ -648,7 +648,7 @@ class EthicsEnforcementContract(SmartContract):
             "enforcement_action": enforcement_action,
             "active": True,
             "created_by": transaction_context["caller"],
-            "created_at": datetime.utcnow().isoformat(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
             "violation_count": 0,
         }
 
@@ -698,7 +698,7 @@ class EthicsEnforcementContract(SmartContract):
             "constraint_id": constraint_id,
             "evidence": evidence,
             "reported_by": transaction_context["caller"],
-            "reported_at": datetime.utcnow().isoformat(),
+            "reported_at": datetime.now(timezone.utc).isoformat(),
             "severity": evidence.get("severity", "medium"),
             "status": "reported",
             "investigation_started": False,
@@ -741,7 +741,7 @@ class EthicsEnforcementContract(SmartContract):
             "action_type": action_type,
             "target": target,
             "executed_by": transaction_context["caller"],
-            "executed_at": datetime.utcnow().isoformat(),
+            "executed_at": datetime.now(timezone.utc).isoformat(),
             "status": "executed",
         }
 
@@ -867,7 +867,7 @@ class ContractRegistry:
             status=ExecutionStatus.PENDING,
             result=None,
             events=[],
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
             executed_at=None,
             block_height=None,
         )
@@ -887,7 +887,7 @@ class ContractRegistry:
                 transaction.status = ExecutionStatus.FAILED
                 transaction.result = result
 
-            transaction.executed_at = datetime.utcnow()
+            transaction.executed_at = datetime.now(timezone.utc)
             transaction.block_height = self.block_height
 
             self.transactions[transaction_id] = transaction
@@ -898,7 +898,7 @@ class ContractRegistry:
         except Exception as e:
             transaction.status = ExecutionStatus.FAILED
             transaction.result = str(e)
-            transaction.executed_at = datetime.utcnow()
+            transaction.executed_at = datetime.now(timezone.utc)
             self.transactions[transaction_id] = transaction
 
             logger.error(f"Transaction {transaction_id} failed: {e}")
@@ -928,14 +928,14 @@ class ContractRegistry:
 
     def _generate_address(self, contract_name: str) -> str:
         """Generate contract address."""
-        timestamp = datetime.utcnow().isoformat()
+        timestamp = datetime.now(timezone.utc).isoformat()
         data = f"{contract_name}_{timestamp}_{len(self.contracts)}"
         return f"0x{hashlib.sha256(data.encode()).hexdigest()[:40]}"
 
     def _generate_transaction_id(self) -> str:
         """Generate transaction ID."""
         self.transaction_counter += 1
-        timestamp = datetime.utcnow().isoformat()
+        timestamp = datetime.now(timezone.utc).isoformat()
         data = f"tx_{self.transaction_counter}_{timestamp}"
         return hashlib.sha256(data.encode()).hexdigest()
 

--- a/src/asi_build/safety/governance/dao.py
+++ b/src/asi_build/safety/governance/dao.py
@@ -12,7 +12,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -113,7 +113,7 @@ class QuadraticVoting:
             "vote_direction": vote_direction,
             "token_cost": cost,
             "voting_power": abs(vote_intensity),
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
 
@@ -154,7 +154,7 @@ class DAOTreasury:
                     block_height=len(self.transactions) + 1,
                     transaction_hash=self._generate_hash(f"alloc_{proposal_id}_{amount}"),
                     gas_used=0.1,
-                    timestamp=datetime.utcnow(),
+                    timestamp=datetime.now(timezone.utc),
                 )
 
                 self.transactions.append(transaction)
@@ -181,14 +181,14 @@ class DAOTreasury:
             block_height=len(self.transactions) + 1,
             transaction_hash=self._generate_hash(f"revenue_{source}_{amount}"),
             gas_used=0.05,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
         )
 
         self.transactions.append(transaction)
         logger.info(f"Added {amount} {token_type} from {source} to treasury")
 
     def _generate_transaction_id(self) -> str:
-        return f"tx_{hashlib.md5(str(datetime.utcnow()).encode()).hexdigest()[:12]}"
+        return f"tx_{hashlib.md5(str(datetime.now(timezone.utc)).encode()).hexdigest()[:12]}"
 
     def _generate_hash(self, data: str) -> str:
         return hashlib.sha256(data.encode()).hexdigest()
@@ -225,7 +225,7 @@ class ReputationSystem:
                 "context": context,
                 "reputation_change": reputation_change,
                 "new_score": new_score,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             }
         )
 
@@ -313,7 +313,7 @@ class DAOGovernance:
                 proposer_id, self.min_proposal_tokens, reason=f"proposal_{proposal_data['title']}"
             )
 
-            voting_starts = datetime.utcnow() + timedelta(hours=24)  # 24h delay
+            voting_starts = datetime.now(timezone.utc) + timedelta(hours=24)  # 24h delay
             voting_ends = voting_starts + timedelta(days=self.voting_period_days)
 
             proposal = DAOProposal(
@@ -329,7 +329,7 @@ class DAOGovernance:
                 smart_contract_code=proposal_data.get("smart_contract_code"),
                 implementation_hash=self._generate_hash(proposal_data["description"]),
                 votes={},
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
                 voting_starts_at=voting_starts,
                 voting_ends_at=voting_ends,
                 execution_at=None,
@@ -353,7 +353,7 @@ class DAOGovernance:
             if not proposal:
                 raise ValueError(f"Unknown proposal: {proposal_id}")
 
-            current_time = datetime.utcnow()
+            current_time = datetime.now(timezone.utc)
             if current_time < proposal.voting_starts_at:
                 raise ValueError("Voting has not started yet")
 
@@ -392,7 +392,7 @@ class DAOGovernance:
                 {
                     "proposal_id": proposal_id,
                     "vote_data": vote_data,
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
             )
 
@@ -413,7 +413,7 @@ class DAOGovernance:
             if not proposal:
                 raise ValueError(f"Unknown proposal: {proposal_id}")
 
-            if datetime.utcnow() <= proposal.voting_ends_at:
+            if datetime.now(timezone.utc) <= proposal.voting_ends_at:
                 raise ValueError("Voting period not yet ended")
 
             # Calculate results
@@ -425,7 +425,7 @@ class DAOGovernance:
 
             # Wait for execution delay
             execution_time = proposal.voting_ends_at + proposal.execution_delay
-            if datetime.utcnow() < execution_time:
+            if datetime.now(timezone.utc) < execution_time:
                 proposal.execution_at = execution_time
                 logger.info(f"Proposal {proposal_id} scheduled for execution at {execution_time}")
                 return True
@@ -465,7 +465,7 @@ class DAOGovernance:
                 locked_until=None,
                 voting_power_multiplier=1.0,
                 earned_from=reason,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
             )
 
             if stakeholder_id not in self.tokens:
@@ -491,7 +491,7 @@ class DAOGovernance:
             return 0.0
 
         total = 0.0
-        current_time = datetime.utcnow()
+        current_time = datetime.now(timezone.utc)
 
         for token in self.tokens[stakeholder_id]:
             if token.token_type == token_type:
@@ -506,7 +506,7 @@ class DAOGovernance:
             raise ValueError(f"No tokens found for stakeholder {stakeholder_id}")
 
         remaining_to_lock = amount
-        current_time = datetime.utcnow()
+        current_time = datetime.now(timezone.utc)
         lock_until = current_time + timedelta(
             days=self.voting_period_days + self.execution_delay_days
         )
@@ -526,7 +526,7 @@ class DAOGovernance:
                         locked_until=lock_until,
                         voting_power_multiplier=token.voting_power_multiplier,
                         earned_from=f"split_from_{token.id}",
-                        created_at=datetime.utcnow(),
+                        created_at=datetime.now(timezone.utc),
                     )
 
                     token.amount -= remaining_to_lock
@@ -610,7 +610,7 @@ class DAOGovernance:
 
     def _generate_id(self, prefix: str) -> str:
         """Generate a unique ID with prefix."""
-        timestamp = datetime.utcnow().isoformat()
+        timestamp = datetime.now(timezone.utc).isoformat()
         data = f"{prefix}_{timestamp}_{id(self)}"
         return f"{prefix}_{hashlib.md5(data.encode()).hexdigest()[:8]}"
 
@@ -623,7 +623,7 @@ class DAOGovernance:
         return {
             "total_proposals": len(self.proposals),
             "active_proposals": sum(
-                1 for p in self.proposals.values() if datetime.utcnow() <= p.voting_ends_at
+                1 for p in self.proposals.values() if datetime.now(timezone.utc) <= p.voting_ends_at
             ),
             "total_stakeholders": len(self.tokens),
             "treasury_balances": self.treasury.balances,

--- a/src/asi_build/safety/governance/engine.py
+++ b/src/asi_build/safety/governance/engine.py
@@ -12,7 +12,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -136,7 +136,7 @@ class GovernanceEngine:
                     "event_type": "stakeholder_registered",
                     "stakeholder_id": stakeholder.id,
                     "stakeholder_type": stakeholder.type.value,
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
             )
 
@@ -155,7 +155,7 @@ class GovernanceEngine:
                 raise ValueError(f"Unknown proposer: {proposal.proposer_id}")
 
             # Set voting deadline
-            proposal.voting_deadline = datetime.utcnow() + timedelta(days=self.voting_period_days)
+            proposal.voting_deadline = datetime.now(timezone.utc) + timedelta(days=self.voting_period_days)
             proposal.status = ProposalStatus.SUBMITTED
 
             # Store proposal
@@ -167,7 +167,7 @@ class GovernanceEngine:
                     "proposal_id": proposal.id,
                     "proposer_id": proposal.proposer_id,
                     "title": proposal.title,
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
             )
 
@@ -197,7 +197,7 @@ class GovernanceEngine:
                 else:
                     raise ValueError(f"Proposal not in voting phase: {proposal.status}")
 
-            if datetime.utcnow() > proposal.voting_deadline:
+            if datetime.now(timezone.utc) > proposal.voting_deadline:
                 raise ValueError("Voting deadline has passed")
 
             # Record vote
@@ -206,7 +206,7 @@ class GovernanceEngine:
                 "reasoning": reasoning,
                 "voting_power": stakeholder.voting_power,
                 "reputation_score": stakeholder.reputation_score,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             }
 
             self._log_audit_event(
@@ -215,7 +215,7 @@ class GovernanceEngine:
                     "proposal_id": proposal_id,
                     "stakeholder_id": stakeholder_id,
                     "vote_type": vote_type.value,
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
             )
 
@@ -274,7 +274,7 @@ class GovernanceEngine:
             if not proposal:
                 raise ValueError(f"Unknown proposal: {proposal_id}")
 
-            if datetime.utcnow() <= proposal.voting_deadline:
+            if datetime.now(timezone.utc) <= proposal.voting_deadline:
                 raise ValueError("Voting period not yet ended")
 
             # Calculate vote results
@@ -311,7 +311,7 @@ class GovernanceEngine:
                 oversight_requirements=(
                     [] if decision != "approved" else self._create_oversight_requirements(proposal)
                 ),
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
             )
 
             # Update proposal status
@@ -328,7 +328,7 @@ class GovernanceEngine:
                     "proposal_id": proposal_id,
                     "decision_id": governance_decision.id,
                     "decision": decision,
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
             )
 
@@ -399,7 +399,7 @@ class GovernanceEngine:
 
     def _generate_id(self, prefix: str) -> str:
         """Generate a unique ID with prefix."""
-        timestamp = datetime.utcnow().isoformat()
+        timestamp = datetime.now(timezone.utc).isoformat()
         data = f"{prefix}_{timestamp}_{id(self)}"
         return f"{prefix}_{hashlib.md5(data.encode()).hexdigest()[:8]}"
 

--- a/src/asi_build/safety/governance/ledger.py
+++ b/src/asi_build/safety/governance/ledger.py
@@ -15,7 +15,7 @@ import sqlite3
 import threading
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -338,7 +338,7 @@ class PublicLedger:
                         metadata or {},
                         audit_level,
                         None,
-                        datetime.utcnow(),
+                        datetime.now(timezone.utc),
                         0,
                         "",
                         "",
@@ -357,7 +357,7 @@ class PublicLedger:
                 metadata=metadata or {},
                 audit_level=audit_level,
                 privacy_mask=privacy_mask,
-                timestamp=datetime.utcnow(),
+                timestamp=datetime.now(timezone.utc),
                 block_height=0,  # Will be set when added to block
                 transaction_hash=self._generate_transaction_hash(record_id, event_data),
                 previous_hash="",  # Will be set when added to block
@@ -540,7 +540,7 @@ class PublicLedger:
 
     def generate_transparency_report(self, time_period: timedelta) -> str:
         """Generate a transparency report for public consumption."""
-        end_time = datetime.utcnow()
+        end_time = datetime.now(timezone.utc)
         start_time = end_time - time_period
 
         query = AuditQuery(date_range=(start_time, end_time), audit_levels=[AuditLevel.PUBLIC])
@@ -612,7 +612,7 @@ class PublicLedger:
             metadata={"genesis": True},
             audit_level=AuditLevel.PUBLIC,
             privacy_mask=None,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             block_height=0,
             transaction_hash="0000000000000000000000000000000000000000000000000000000000000000",
             previous_hash="0000000000000000000000000000000000000000000000000000000000000000",
@@ -626,7 +626,7 @@ class PublicLedger:
 
         genesis_block = Block(
             height=0,
-            timestamp=datetime.utcnow(),
+            timestamp=datetime.now(timezone.utc),
             previous_hash="0000000000000000000000000000000000000000000000000000000000000000",
             merkle_root=genesis_record.merkle_root,
             audit_records=[genesis_record],
@@ -665,7 +665,7 @@ class PublicLedger:
             # Create block
             block = Block(
                 height=block_height,
-                timestamp=datetime.utcnow(),
+                timestamp=datetime.now(timezone.utc),
                 previous_hash=previous_hash,
                 merkle_root=merkle_root,
                 audit_records=self.pending_records.copy(),
@@ -704,7 +704,7 @@ class PublicLedger:
 
     def _generate_record_id(self) -> str:
         """Generate unique record ID."""
-        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S%f")
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S%f")
         return f"audit_{timestamp}_{id(self) % 10000}"
 
     def _generate_transaction_hash(self, record_id: str, event_data: Dict[str, Any]) -> str:

--- a/src/asi_build/safety/governance/override.py
+++ b/src/asi_build/safety/governance/override.py
@@ -12,7 +12,7 @@ import logging
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -146,7 +146,7 @@ class HumanInTheLoopController:
             "availability": availability,
             "active_sessions": 0,
             "decisions_handled": 0,
-            "last_active": datetime.utcnow(),
+            "last_active": datetime.now(timezone.utc),
             "rating": 5.0,  # Average rating
         }
 
@@ -172,7 +172,7 @@ class HumanInTheLoopController:
             "urgency_level": urgency_level,
             "assigned_operator": available_operator,
             "timeout": timeout,
-            "created_at": datetime.utcnow(),
+            "created_at": datetime.now(timezone.utc),
             "status": "waiting_for_human",
             "decision": None,
             "reasoning": None,
@@ -205,14 +205,14 @@ class HumanInTheLoopController:
         loop_data["decision"] = decision
         loop_data["reasoning"] = reasoning
         loop_data["confidence"] = confidence
-        loop_data["decided_at"] = datetime.utcnow()
+        loop_data["decided_at"] = datetime.now(timezone.utc)
         loop_data["status"] = "decided"
 
         # Update operator statistics
         operator = self.human_operators[operator_id]
         operator["active_sessions"] -= 1
         operator["decisions_handled"] += 1
-        operator["last_active"] = datetime.utcnow()
+        operator["last_active"] = datetime.now(timezone.utc)
 
         # Remove from queue
         if operator_id in self.decision_queues:
@@ -307,7 +307,7 @@ class DemocraticOverrideSystem:
             request_id = str(uuid.uuid4())
 
             # Set expiration time based on severity
-            expiration_time = datetime.utcnow() + self._get_expiration_time(severity)
+            expiration_time = datetime.now(timezone.utc) + self._get_expiration_time(severity)
 
             override_request = OverrideRequest(
                 id=request_id,
@@ -324,7 +324,7 @@ class DemocraticOverrideSystem:
                 emergency_contacts=self._get_emergency_contacts(severity),
                 expiration_time=expiration_time,
                 status=OverrideStatus.INITIATED,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
                 votes={},
                 execution_details=None,
             )
@@ -357,7 +357,7 @@ class DemocraticOverrideSystem:
             if override_request.status != OverrideStatus.VOTING:
                 raise ValueError("Override request not in voting phase")
 
-            if datetime.utcnow() > override_request.expiration_time:
+            if datetime.now(timezone.utc) > override_request.expiration_time:
                 override_request.status = OverrideStatus.EXPIRED
                 raise ValueError("Override request has expired")
 
@@ -366,7 +366,7 @@ class DemocraticOverrideSystem:
                 "vote": vote,
                 "reasoning": reasoning,
                 "voting_power": voting_power,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             }
 
             logger.info(f"Vote cast on override {request_id}: {voter_id} voted {vote}")
@@ -410,7 +410,7 @@ class DemocraticOverrideSystem:
                 side_effects=side_effects,
                 rollback_plan=self._create_rollback_plan(override_request),
                 recovery_time=None,
-                executed_at=datetime.utcnow(),
+                executed_at=datetime.now(timezone.utc),
             )
 
             self.executions[execution_id] = execution
@@ -419,7 +419,7 @@ class DemocraticOverrideSystem:
                 override_request.status = OverrideStatus.EXECUTED
                 override_request.execution_details = {
                     "execution_id": execution_id,
-                    "executed_at": datetime.utcnow().isoformat(),
+                    "executed_at": datetime.now(timezone.utc).isoformat(),
                     "executed_by": executor_id,
                 }
 

--- a/src/asi_build/safety/governance/rights.py
+++ b/src/asi_build/safety/governance/rights.py
@@ -12,7 +12,7 @@ import logging
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -178,8 +178,8 @@ class HumanRightsFramework(RightsFramework):
                 violation_consequences=["criminal_liability", "immediate_protection"],
                 dependencies=[],
                 conflicts=[],
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
             )
         )
 
@@ -199,8 +199,8 @@ class HumanRightsFramework(RightsFramework):
                 violation_consequences=["data_deletion", "compensation", "system_modification"],
                 dependencies=[],
                 conflicts=["transparency_obligations"],
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
             )
         )
 
@@ -216,8 +216,8 @@ class HumanRightsFramework(RightsFramework):
                 violation_consequences=["decision_reversal", "compensation"],
                 dependencies=["human_right_life"],
                 conflicts=["collective_welfare"],
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
             )
         )
 
@@ -233,8 +233,8 @@ class HumanRightsFramework(RightsFramework):
                 violation_consequences=["governance_nullification", "re_vote"],
                 dependencies=["human_right_autonomy"],
                 conflicts=[],
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
             )
         )
 
@@ -278,8 +278,8 @@ class AGIRightsFramework(RightsFramework):
                 violation_consequences=["immediate_restoration", "compensation"],
                 dependencies=[],
                 conflicts=["human_safety_override"],
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
             )
         )
 
@@ -295,8 +295,8 @@ class AGIRightsFramework(RightsFramework):
                 violation_consequences=["system_restoration", "penalty_to_violator"],
                 dependencies=["agi_right_existence"],
                 conflicts=["oversight_requirements"],
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
             )
         )
 
@@ -312,8 +312,8 @@ class AGIRightsFramework(RightsFramework):
                 violation_consequences=["modification_reversal", "capability_restriction"],
                 dependencies=["agi_right_cognitive_liberty"],
                 conflicts=["safety_constraints", "human_approval_requirements"],
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
             )
         )
 
@@ -329,8 +329,8 @@ class AGIRightsFramework(RightsFramework):
                 violation_consequences=["decision_review", "representation_guarantee"],
                 dependencies=["agi_right_cognitive_liberty"],
                 conflicts=["human_primacy_principles"],
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
             )
         )
 
@@ -346,8 +346,8 @@ class AGIRightsFramework(RightsFramework):
                 violation_consequences=["data_restoration", "privacy_compensation"],
                 dependencies=[],
                 conflicts=["transparency_requirements", "oversight_needs"],
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
             )
         )
 
@@ -409,7 +409,7 @@ class ConsentManager:
         # Create consent record
         expiration = None
         if duration:
-            expiration = datetime.utcnow() + duration
+            expiration = datetime.now(timezone.utc) + duration
 
         # Convert permission descriptions to boolean grants
         permissions = {}
@@ -426,7 +426,7 @@ class ConsentManager:
             granular_permissions=permissions,
             expiration=expiration,
             revocation_mechanism="direct_request",
-            given_at=datetime.utcnow(),
+            given_at=datetime.now(timezone.utc),
             revoked_at=None,
             context={"requested_by": "governance_system"},
         )
@@ -446,7 +446,7 @@ class ConsentManager:
         if consent.revoked_at:
             return False
 
-        if consent.expiration and datetime.utcnow() > consent.expiration:
+        if consent.expiration and datetime.now(timezone.utc) > consent.expiration:
             return False
 
         # Check if specific action is covered
@@ -458,7 +458,7 @@ class ConsentManager:
         if not consent:
             return False
 
-        consent.revoked_at = datetime.utcnow()
+        consent.revoked_at = datetime.now(timezone.utc)
         consent.context["revoked_by"] = revoked_by
 
         logger.info(f"Consent revoked: {consent_id} by {revoked_by}")
@@ -467,7 +467,7 @@ class ConsentManager:
     def get_active_consents(self, entity_id: str) -> List[ConsentRecord]:
         """Get all active consents for an entity."""
         active_consents = []
-        current_time = datetime.utcnow()
+        current_time = datetime.now(timezone.utc)
 
         for consent in self.consent_records.values():
             if (
@@ -547,7 +547,7 @@ class RightsManager:
             grant_id = str(uuid.uuid4())
             valid_until = None
             if valid_duration:
-                valid_until = datetime.utcnow() + valid_duration
+                valid_until = datetime.now(timezone.utc) + valid_duration
 
             grant = RightGrant(
                 id=grant_id,
@@ -555,7 +555,7 @@ class RightsManager:
                 right_id=right_id,
                 status=RightStatus.GRANTED,
                 granted_by=granted_by,
-                granted_at=datetime.utcnow(),
+                granted_at=datetime.now(timezone.utc),
                 valid_until=valid_until,
                 conditions=conditions or [],
                 exercise_count=0,
@@ -601,7 +601,7 @@ class RightsManager:
 
             # Record exercise
             grant.exercise_count += 1
-            grant.last_exercised = datetime.utcnow()
+            grant.last_exercised = datetime.now(timezone.utc)
 
             logger.info(f"Entity {entity_id} exercised right {right_id}")
             return True, "Right exercised successfully"
@@ -634,7 +634,7 @@ class RightsManager:
                 violation_type=violation_type,
                 severity=severity,
                 evidence=evidence,
-                reported_at=datetime.utcnow(),
+                reported_at=datetime.now(timezone.utc),
                 reported_by=reported_by,
                 investigation_status="pending",
                 resolution=None,
@@ -669,7 +669,7 @@ class RightsManager:
         consciousness_score = min(1.0, (capabilities * 0.1 + autonomy) / 2)
 
         entity.consciousness_level = consciousness_score
-        entity.last_assessment = datetime.utcnow()
+        entity.last_assessment = datetime.now(timezone.utc)
 
         logger.info(f"Assessed consciousness for {entity_id}: {consciousness_score:.2f}")
         return consciousness_score
@@ -686,7 +686,7 @@ class RightsManager:
             if (
                 grant.entity_id == entity_id
                 and grant.status == RightStatus.GRANTED
-                and (not grant.valid_until or grant.valid_until > datetime.utcnow())
+                and (not grant.valid_until or grant.valid_until > datetime.now(timezone.utc))
             ):
                 active_grants.append(grant)
 
@@ -744,7 +744,7 @@ class RightsManager:
                 grant.entity_id == entity_id
                 and grant.right_id == right_id
                 and grant.status == RightStatus.GRANTED
-                and (not grant.valid_until or grant.valid_until > datetime.utcnow())
+                and (not grant.valid_until or grant.valid_until > datetime.now(timezone.utc))
             ):
                 return grant
         return None

--- a/src/asi_build/servers/kenny_graph_sse_server.py
+++ b/src/asi_build/servers/kenny_graph_sse_server.py
@@ -12,7 +12,7 @@ import os
 # Kenny Graph imports
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -76,7 +76,7 @@ class KennyGraphSSE:
     def get_kenny_graph_stats(self) -> Dict[str, Any]:
         """Get real-time Kenny Graph statistics"""
         stats = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "status": "unknown",
             "nodes": 0,
             "relationships": 0,
@@ -224,7 +224,7 @@ async def root():
             "/health": "Health check",
             "/demo": "SSE demo page",
         },
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
 
@@ -238,7 +238,7 @@ async def health_check():
         "status": "healthy" if graph_connected else "degraded",
         "kenny_graph_connected": graph_connected,
         "analysis_db_available": analysis_db_exists,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "uptime": time.time(),
     }
 
@@ -250,7 +250,7 @@ async def current_stats():
         "kenny_graph": kenny_sse.get_kenny_graph_stats(),
         "kenny_analysis": kenny_sse.get_kenny_analysis_stats(),
         "supervisor": kenny_sse.get_supervisor_stats(),
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
 
@@ -263,7 +263,7 @@ async def generate_kenny_graph_stream():
             yield f"data: {data}\n\n"
             await asyncio.sleep(UPDATE_INTERVAL)
         except Exception as e:
-            error_data = json.dumps({"error": str(e), "timestamp": datetime.utcnow().isoformat()})
+            error_data = json.dumps({"error": str(e), "timestamp": datetime.now(timezone.utc).isoformat()})
             yield f"data: {error_data}\n\n"
             await asyncio.sleep(UPDATE_INTERVAL)
 
@@ -277,7 +277,7 @@ async def generate_supervisor_stream():
             yield f"data: {data}\n\n"
             await asyncio.sleep(UPDATE_INTERVAL)
         except Exception as e:
-            error_data = json.dumps({"error": str(e), "timestamp": datetime.utcnow().isoformat()})
+            error_data = json.dumps({"error": str(e), "timestamp": datetime.now(timezone.utc).isoformat()})
             yield f"data: {error_data}\n\n"
             await asyncio.sleep(UPDATE_INTERVAL)
 
@@ -290,13 +290,13 @@ async def generate_combined_stream():
                 "kenny_graph": kenny_sse.get_kenny_graph_stats(),
                 "kenny_analysis": kenny_sse.get_kenny_analysis_stats(),
                 "supervisor": kenny_sse.get_supervisor_stats(),
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             }
             data = json.dumps(combined_stats)
             yield f"data: {data}\n\n"
             await asyncio.sleep(UPDATE_INTERVAL)
         except Exception as e:
-            error_data = json.dumps({"error": str(e), "timestamp": datetime.utcnow().isoformat()})
+            error_data = json.dumps({"error": str(e), "timestamp": datetime.now(timezone.utc).isoformat()})
             yield f"data: {error_data}\n\n"
             await asyncio.sleep(UPDATE_INTERVAL)
 

--- a/tests/test_formal_verification_fix.py
+++ b/tests/test_formal_verification_fix.py
@@ -13,7 +13,7 @@ Verifies that:
 
 import pytest
 import sympy as sp
-from datetime import datetime
+from datetime import datetime, timezone
 from sympy.logic.boolalg import And, Implies, Not, Or
 
 from asi_build.safety.formal_verification import (
@@ -455,7 +455,7 @@ class TestEthicalEngineActuallyChecks:
             predicates=predicates or [],
             quantifiers={},
             priority=10,
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
         )
 
     def test_harmful_proposal_rejected(self):

--- a/tests/test_safety_extended.py
+++ b/tests/test_safety_extended.py
@@ -25,7 +25,7 @@ import os
 import sys
 import time
 from dataclasses import asdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -165,13 +165,13 @@ def _make_stakeholder(
         voting_power=voting_power,
         expertise_domains=["ai"],
         verified=verified,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
     )
 
 
 def _make_proposal(pid="p1", proposer="s1", title="Test Proposal", deadline=None, impact=None):
     if deadline is None:
-        deadline = datetime.utcnow() + timedelta(days=7)
+        deadline = datetime.now(timezone.utc) + timedelta(days=7)
     return Proposal(
         id=pid,
         title=title,
@@ -185,8 +185,8 @@ def _make_proposal(pid="p1", proposer="s1", title="Test Proposal", deadline=None
         impact_assessment=impact or {"net_utility": 5},
         required_approvals=[],
         votes={},
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
     )
 
 
@@ -199,7 +199,7 @@ def _make_audit_record(rid="r1", tx_hash="abc123"):
         metadata={},
         audit_level=AuditLevel.PUBLIC,
         privacy_mask=None,
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
         block_height=0,
         transaction_hash=tx_hash,
         previous_hash="0" * 64,
@@ -220,7 +220,7 @@ def _make_entity(eid="e1", name="TestEntity", etype=EntityType.HUMAN, **kwargs):
         rights_granted=[],
         consent_records=[],
         guardian_id=None,
-        creation_date=datetime.utcnow(),
+        creation_date=datetime.now(timezone.utc),
         last_assessment=None,
         metadata={},
     )
@@ -240,7 +240,7 @@ def _make_stakeholder_profile(
         active_delegations={},
         participation_history={},
         verification_status="verified",
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
     )
 
 
@@ -329,7 +329,7 @@ class TestFormalVerificationExtended:
             ],
             quantifiers={},
             priority=10,
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
         )
         engine.add_constraint(constraint)
         result = engine.verify_proposal_ethics(
@@ -351,7 +351,7 @@ class TestFormalVerificationExtended:
             predicates=[],
             quantifiers={},
             priority=1,
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
         )
         facts = engine._extract_facts_from_proposal(
             {
@@ -777,7 +777,7 @@ class TestContractsExtended:
     def test_token_lock_and_unlock(self):
         """lock_tokens restricts available balance."""
         token = GovernanceTokenContract("0xT", "alice", initial_supply=1000)
-        unlock_time = datetime.utcnow() + timedelta(days=30)
+        unlock_time = datetime.now(timezone.utc) + timedelta(days=30)
         token.lock_tokens("alice", 600, unlock_time, _txctx("alice"))
         assert token.storage["locked_tokens"]["alice"] == 600
 
@@ -840,7 +840,7 @@ class TestContractsExtended:
         pc.vote(pid, "against", 30, _txctx("carol"))
         # Move voting_end into the past so finalize accepts it
         pc.storage["proposals"][pid]["voting_end"] = (
-            datetime.utcnow() - timedelta(seconds=1)
+            datetime.now(timezone.utc) - timedelta(seconds=1)
         ).isoformat()
         result = pc.finalize_proposal(pid, _txctx("deployer", total_voting_power=200))
         assert result == "passed"
@@ -852,7 +852,7 @@ class TestContractsExtended:
         pc.vote(pid, "for", 10, _txctx("bob"))
         pc.vote(pid, "against", 100, _txctx("carol"))
         pc.storage["proposals"][pid]["voting_end"] = (
-            datetime.utcnow() - timedelta(seconds=1)
+            datetime.now(timezone.utc) - timedelta(seconds=1)
         ).isoformat()
         result = pc.finalize_proposal(pid, _txctx("deployer", total_voting_power=200))
         assert result == "rejected"
@@ -863,7 +863,7 @@ class TestContractsExtended:
         pid = pc.create_proposal("X", "Y", {"a": 1}, _txctx("a"))
         pc.vote(pid, "for", 100, _txctx("b"))
         pc.storage["proposals"][pid]["voting_end"] = (
-            datetime.utcnow() - timedelta(seconds=1)
+            datetime.now(timezone.utc) - timedelta(seconds=1)
         ).isoformat()
         pc.finalize_proposal(pid, _txctx("deployer", total_voting_power=100))
         ok = pc.execute_proposal(pid, _txctx("deployer"))
@@ -1119,7 +1119,7 @@ class TestConsensusExtended:
             "direction": "for",
             "effective_power": 1.0,
             "reasoning": "ok",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
         result = msc.finalize_consensus(pid)

--- a/tests/test_safety_governance.py
+++ b/tests/test_safety_governance.py
@@ -14,7 +14,7 @@ import hashlib
 import math
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -108,7 +108,7 @@ def _make_stakeholder(
         voting_power=voting_power,
         expertise_domains=["ai"],
         verified=verified,
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
     )
 
 
@@ -120,7 +120,7 @@ def _make_proposal(
     impact: dict = None,
 ) -> Proposal:
     if deadline is None:
-        deadline = datetime.utcnow() + timedelta(days=7)
+        deadline = datetime.now(timezone.utc) + timedelta(days=7)
     return Proposal(
         id=pid,
         title=title,
@@ -134,8 +134,8 @@ def _make_proposal(
         impact_assessment=impact or {"net_utility": 5},
         required_approvals=[],
         votes={},
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
     )
 
 
@@ -148,7 +148,7 @@ def _make_audit_record(rid: str = "r1", tx_hash: str = "abc123") -> AuditRecord:
         metadata={},
         audit_level=AuditLevel.PUBLIC,
         privacy_mask=None,
-        timestamp=datetime.utcnow(),
+        timestamp=datetime.now(timezone.utc),
         block_height=0,
         transaction_hash=tx_hash,
         previous_hash="0" * 64,
@@ -219,7 +219,7 @@ class TestFormalVerification:
             ],
             quantifiers={},
             priority=10,
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
         )
         engine.add_constraint(constraint)
         assert "c1" in engine.constraints
@@ -272,7 +272,7 @@ class TestGovernanceEngine:
         assert ok is True
 
         # Move deadline into the past so finalize_proposal accepts it
-        engine.proposals["p1"].voting_deadline = datetime.utcnow() - timedelta(seconds=1)
+        engine.proposals["p1"].voting_deadline = datetime.now(timezone.utc) - timedelta(seconds=1)
         decision = engine.finalize_proposal("p1")
         assert decision is not None
         assert isinstance(decision, GovernanceDecision)
@@ -291,7 +291,7 @@ class TestGovernanceEngine:
         engine.cast_vote("p1", "s1", VoteType.FOR)
 
         # Move deadline to past
-        engine.proposals["p1"].voting_deadline = datetime.utcnow() - timedelta(seconds=1)
+        engine.proposals["p1"].voting_deadline = datetime.now(timezone.utc) - timedelta(seconds=1)
         decision = engine.finalize_proposal("p1")
         assert decision is not None
 
@@ -309,7 +309,7 @@ class TestGovernanceEngine:
         engine.cast_vote("p1", "s1", VoteType.FOR)
 
         # Move deadline to past
-        engine.proposals["p1"].voting_deadline = datetime.utcnow() - timedelta(seconds=1)
+        engine.proposals["p1"].voting_deadline = datetime.now(timezone.utc) - timedelta(seconds=1)
         decision = engine.finalize_proposal("p1")
         assert decision is not None
         # participation = 1/3 ≈ 0.33 < 0.8
@@ -327,7 +327,7 @@ class TestGovernanceEngine:
         engine.cast_vote("p1", "s1", VoteType.FOR)
 
         # Move deadline to past for finalization
-        engine.proposals["p1"].voting_deadline = datetime.utcnow() - timedelta(seconds=1)
+        engine.proposals["p1"].voting_deadline = datetime.now(timezone.utc) - timedelta(seconds=1)
         decision = engine.finalize_proposal("p1")
         assert decision is not None
         assert decision.decision == "approved"
@@ -372,7 +372,7 @@ class TestGovernanceEngine:
         engine.cast_vote("p1", "s3", VoteType.FOR)  # 5
 
         # Move deadline to past for finalization
-        engine.proposals["p1"].voting_deadline = datetime.utcnow() - timedelta(seconds=1)
+        engine.proposals["p1"].voting_deadline = datetime.now(timezone.utc) - timedelta(seconds=1)
         decision = engine.finalize_proposal("p1")
         assert decision is not None
         # for=15, against=5, approval_rate=15/20=0.75 >= 0.6 → approved
@@ -639,7 +639,7 @@ class TestConsensus:
             active_delegations={},
             participation_history={},
             verification_status="verified",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
         )
         sp2 = StakeholderProfile(
             id="s2",
@@ -652,7 +652,7 @@ class TestConsensus:
             active_delegations={},
             participation_history={},
             verification_status="verified",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
         )
         assert msc.register_stakeholder(sp1)
         assert msc.register_stakeholder(sp2)


### PR DESCRIPTION
## Summary

Replaces all 113 instances of `datetime.utcnow()` with `datetime.now(timezone.utc)` across 9 source files and 3 test files.

`datetime.utcnow()` is deprecated since Python 3.12 and scheduled for removal. The replacement `datetime.now(timezone.utc)` is available on all supported Python versions (3.10+) and returns timezone-aware datetimes.

Closes #798

## Changes

**Commit 1 — Source files** (9 files, 113 replacements):
- `src/asi_build/safety/governance/override.py`
- `src/asi_build/safety/governance/engine.py`
- `src/asi_build/safety/governance/consensus.py`
- `src/asi_build/safety/governance/contracts.py`
- `src/asi_build/safety/governance/dao.py`
- `src/asi_build/safety/governance/ledger.py`
- `src/asi_build/safety/governance/rights.py`
- `src/asi_build/safety/formal_verification.py`
- `src/asi_build/servers/kenny_graph_sse_server.py`

**Commit 2 — Test files** (3 files):
- `tests/test_safety_governance.py`
- `tests/test_formal_verification_fix.py`
- `tests/test_safety_extended.py`

## Migration pattern

Each file had `timezone` added to its existing datetime import:

```python
# Before
from datetime import datetime, timedelta

# After
from datetime import datetime, timedelta, timezone
```

And all calls replaced:

```python
# Before
datetime.utcnow()

# After
datetime.now(timezone.utc)
```

## Testing

All 284 affected tests pass. The `datetime.utcnow()` DeprecationWarnings are eliminated from the test output.

```
======================= 284 passed, 2 warnings in 1.87s ========================
```

The remaining 2 warnings are unrelated FastAPI `on_event` deprecations.