### PR TITLE
fix(security): remove hardcoded deployer private key from e2e test

### DIFF
--- a/tests/test_bridge_e2e_sepolia.py
+++ b/tests/test_bridge_e2e_sepolia.py
@@ -43,7 +43,7 @@ BRIDGE = "0xE034d479EDc2530d9917dDa4547b59bF0964A2Ca"
 TOKEN = "0x257dDA1fa34eb847060EcB743E808B65099FB497"
 USDC = "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
 DEPLOYER = "0x35C3770470F57560beBd1C6C74366b0297110Bc2"
-DEPLOYER_KEY = "0x7fb897978f5c645a317049f54a4f517c4d1c8e47661fa0bc43211409823215fd"
+DEPLOYER_KEY = os.environ.get("DEPLOYER_PRIVATE_KEY", "")
 SEPOLIA_RPC = "https://ethereum-sepolia-rpc.publicnode.com"
 
 # A deterministic test Rings DID (bytes32)
@@ -187,6 +187,13 @@ def _parse_address(raw: str) -> str:
 # ═══════════════════════════════════════════════════════════════════════════
 #  Fixtures
 # ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _require_deployer_key():
+    """Skip the entire session if DEPLOYER_PRIVATE_KEY is not set."""
+    if not DEPLOYER_KEY:
+        pytest.skip("DEPLOYER_PRIVATE_KEY env var not set — skipping e2e bridge tests")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary

Removes the hardcoded deployer private key (`0x7fb8...15fd`) from `tests/test_bridge_e2e_sepolia.py` and replaces it with `os.environ.get("DEPLOYER_PRIVATE_KEY")`.

Closes #1241

## Problem

The deployer private key was hardcoded at line 46. This key controls `GUARDIAN_ROLE` + `DEFAULT_ADMIN_ROLE` on all 3 deployed bridge contracts (Sepolia, Base Sepolia, ARC Testnet). Anyone who clones the repo has admin access to all bridge contracts.

## Fix

1. Replaced `DEPLOYER_KEY = "0x7fb8..."` with `DEPLOYER_KEY = os.environ.get("DEPLOYER_PRIVATE_KEY", "")`
2. Added a `session`-scoped `autouse` fixture that skips the entire test module when the env var is not set
3. Follows the same pattern already used in `scripts/cross_chain_e2e.py`

## Note

The exposed key should still be rotated and admin roles transferred to a new deployer address — this PR only removes the key from the codebase.